### PR TITLE
Pull Request: Add Customization Options to QuickNotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A handy notepad for Don't Starve Together that lets you jot down important infor
 | 💾 **Auto-Saving** | Automatically saves your notes every 30 seconds |
 | 🖋️ **Enhanced Cursor** | White cursor for better visibility in the text editor |
 | 🎨 **Clean Design** | Unobtrusive interface that fits the DST aesthetic |
+| 🎭 **Customizable Colors** | Personalize text and background colors to suit your preference |
+| 🔍 **Adjustable Transparency** | Control background opacity for better visibility during gameplay |
 
 ## 🔑 Keyboard Shortcuts
 
@@ -49,7 +51,9 @@ A handy notepad for Don't Starve Together that lets you jot down important infor
 The mod can be configured in the mod configuration menu:
 
 - **Toggle Key**: Choose which key opens the notepad (Default: `N`)
-- More customization options coming in future updates!
+- **Text Color**: Select from White, Yellow, Light Blue, Light Green, or Pink
+- **Background Color**: Choose from Dark, Brown, Grey, Blue, or Green
+- **Background Opacity**: Adjust transparency from Solid to Very Transparent
 
 ## 🐛 Reporting Issues
 
@@ -87,7 +91,13 @@ To help diagnose issues, please include your log file:
 
 ## 🔄 Version History
 
-### v0.4.0 (Current)
+### v0.5.0 (Current)
+- Added customizable text colors with 5 options
+- Added customizable background colors with 5 options
+- Added adjustable background transparency
+- Improved mod configuration options
+
+### v0.4.0
 - Added full keyboard navigation with arrow keys
 - Added Home/End keys to jump to start/end of line
 - Added Page Up/Down support for faster navigation
@@ -115,9 +125,9 @@ To help diagnose issues, please include your log file:
 - 📑 Multiple pages/tabs for organization
 - 🔍 Search functionality
 - 📋 Copy/paste support
-- 🎨 Customizable themes and appearance
 - 🖋️ Basic text formatting (bold, italic)
-- Pin notepad button
+- 📌 Pin notepad button
+- 🎭 More theme options and font choices
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A handy notepad for Don't Starve Together that lets you jot down important infor
 | 🖋️ **Enhanced Cursor** | White cursor for better visibility in the text editor |
 | 🎨 **Clean Design** | Unobtrusive interface that fits the DST aesthetic |
 | 🎭 **Customizable Colors** | Personalize text and background colors to suit your preference |
-| 🔍 **Adjustable Transparency** | Control background opacity for better visibility during gameplay |
+| 🔍 **Adjustable Transparency** | Control background opacity for better visibility on your mod list |
 
 ## 🔑 Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This mod is released under the MIT License. See the [LICENSE](LICENSE) file for 
 
 - Created by Heegon Kim (Lumen)
 - Thanks to all users for your feedback and support!
-- Special thanks to the DST modding community
+- Special thanks to the DST modding community ❤️
 
 ---
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,91 @@
+# QuickNotes: Customization Features
+
+This document explains the customization options available in QuickNotes v0.5.0 and how they're implemented.
+
+## Available Customization Options
+
+QuickNotes now allows users to customize the appearance in several ways:
+
+### Text Color Options
+
+You can change the color of text in the notepad with these preset options:
+
+| Option | Description | RGB Value |
+|--------|-------------|-----------|
+| White | Clean white text (Default) | `{ r = 1, g = 1, b = 1, a = 1 }` |
+| Yellow | Warm yellow tint | `{ r = 1, g = 0.9, b = 0.5, a = 1 }` |
+| Light Blue | Soft blue tone | `{ r = 0.6, g = 0.8, b = 1, a = 1 }` |
+| Light Green | Gentle green shade | `{ r = 0.6, g = 1, b = 0.6, a = 1 }` |
+| Pink | Subtle pink hue | `{ r = 1, g = 0.7, b = 0.9, a = 1 }` |
+
+### Background Color Options
+
+Background colors affect both the frame and title bar:
+
+| Option | Description | RGB Base Value (before opacity) |
+|--------|-------------|--------------------------------|
+| Dark | Dark grey (Default) | `{ r = 0.1, g = 0.1, b = 0.1 }` |
+| Brown | Parchment-like brown | `{ r = 0.25, g = 0.15, b = 0.1 }` |
+| Grey | Neutral grey | `{ r = 0.2, g = 0.2, b = 0.23 }` |
+| Blue | Dark blue tone | `{ r = 0.1, g = 0.1, b = 0.25 }` |
+| Green | Deep forest green | `{ r = 0.1, g = 0.2, b = 0.15 }` |
+| Pink | Soft pink shade | `{ r = 0.3, g = 0.1, b = 0.2 }` |
+
+### Transparency Options
+
+You can adjust how transparent the notepad background appears:
+
+| Option | Description | Alpha Value |
+|--------|-------------|-------------|
+| Solid | Nearly opaque | 0.7 |
+| Semi-Transparent | Moderately transparent | 0.5 |
+| More Transparent | Quite see-through | 0.3 |
+| Very Transparent | Highly transparent | 0.1 |
+
+## Implementation Details
+
+The customization system works by:
+
+1. Defining user options in `modinfo.lua` as configurable settings
+2. Loading these settings in `config.lua` using `GetModConfigData()`
+3. Converting user selections to RGB color values using mapping tables
+4. Applying these colors to UI elements when rendering the notepad
+
+### Color Processing Flow
+
+1. User selects options in the mod configuration menu
+2. Settings are loaded when the mod initializes
+3. `config.lua` maps selections to appropriate RGBA values 
+4. UI components use these values when setting colors
+
+### Key Files
+
+- `modinfo.lua`: Contains the configuration options definitions
+- `scripts/notepad/config.lua`: Processes user settings and maps them to actual color values
+- `scripts/widgets/notepad_ui.lua`: Applies the colors to visual elements
+
+## Using Custom Colors in Development
+
+When creating new UI elements, use the standard color references from `config.lua` to ensure they respect user customization choices:
+
+```lua
+-- Example of using customized colors
+local config = require "notepad/config"
+
+my_element:SetTint(
+    config.COLORS.FRAME_TINT.r,
+    config.COLORS.FRAME_TINT.g,
+    config.COLORS.FRAME_TINT.b,
+    config.COLORS.FRAME_TINT.a
+)
+```
+
+## Future Customization Plans
+
+In future versions, we plan to expand customization options with:
+
+- Font selection for different text styles
+- Additional color presets with more variety
+- Custom theme combinations (preconfigured color sets)
+- Individual element coloring (separate title, frame, editor colors)
+- Size/scale adjustment options

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -17,6 +17,8 @@ Features:
 - Supports up to 10,000 characters
 - Full keyboard navigation with arrow keys, Home/End, Page Up/Down
 - White cursor for better visibility
+- Customizable text color and background
+- Adjustable background transparency
 - Click outside to close
 
 Keyboard Shortcuts:
@@ -30,7 +32,7 @@ Keyboard Shortcuts:
 - Enter for new lines]]
 
 author = "Lumen"
-version = "0.4.0"
+version = "0.5.0"
 
 --[[ Compatibility Settings
     These flags determine which game versions can use the mod:
@@ -73,5 +75,44 @@ configuration_options = {
             {description = "P", data = "KEY_P"},
         },
         default = "KEY_N",           -- Default key binding
+    },
+    {
+        name = "TEXT_COLOR",
+        label = "Text Color",
+        hover = "Change the color of the notepad text",
+        options = {
+            {description = "White", data = "WHITE"}, 
+            {description = "Yellow", data = "YELLOW"},
+            {description = "Light Blue", data = "LIGHT_BLUE"},
+            {description = "Light Green", data = "LIGHT_GREEN"},
+            {description = "Pink", data = "PINK"},
+        },
+        default = "WHITE",
+    },
+    {
+        name = "BG_COLOR",
+        label = "Background Color",
+        hover = "Change the background color of the notepad",
+        options = {
+            {description = "Dark", data = "DARK"},
+            {description = "Brown", data = "BROWN"},
+            {description = "Grey", data = "GREY"},
+            {description = "Blue", data = "BLUE"},
+            {description = "Green", data = "GREEN"},
+            {description = "Pink", data = "PINK"},
+        },
+        default = "DARK",
+    },
+    {
+        name = "BG_OPACITY",
+        label = "Background Opacity",
+        hover = "Adjust the transparency of the notepad background",
+        options = {
+            {description = "Solid", data = 0.7},
+            {description = "Semi-Transparent", data = 0.5},
+            {description = "More Transparent", data = 0.3},
+            {description = "Very Transparent", data = 0.1},
+        },
+        default = 0.7,
     }
 }

--- a/modmain.lua
+++ b/modmain.lua
@@ -20,6 +20,9 @@ local require = _G.require
 
 -- Load user configuration
 local TOGGLE_KEY = GetModConfigData("TOGGLE_KEY")
+local TEXT_COLOR = GetModConfigData("TEXT_COLOR")
+local BG_COLOR = GetModConfigData("BG_COLOR")
+local BG_OPACITY = GetModConfigData("BG_OPACITY")
 
 --[[
     Asset Registration
@@ -35,6 +38,16 @@ Assets = {
     Asset("ATLAS", "modicon.xml"),
     Asset("IMAGE", "modicon.tex"),
 }
+
+-- Load configuration module and update it with user settings
+_G.CONFIG_INITIALIZED = false
+_G.InitializeConfig = function()
+    if not _G.CONFIG_INITIALIZED then
+        local Config = require "notepad/config"
+        Config.UpdateConfig(TEXT_COLOR, BG_COLOR, BG_OPACITY)
+        _G.CONFIG_INITIALIZED = true
+    end
+end
 
 -- Make the notepad widget accessible globally
 _G.NotepadWidget = require "widgets/notepadwidget"
@@ -55,6 +68,9 @@ local notepad = nil
 ]]
 local function ToggleNotepad()
     print("[Quick Notes] Toggle Notepad called, key pressed:", TOGGLE_KEY)
+    
+    -- Initialize config before creating notepad
+    _G.InitializeConfig()
     
     -- Safety check: ensure player and HUD exist
     if not _G.ThePlayer or not _G.ThePlayer.HUD then

--- a/scripts/notepad/config.lua
+++ b/scripts/notepad/config.lua
@@ -31,7 +31,7 @@ local BG_COLOR_MAP = {
     GREY = { r = 0.2, g = 0.2, b = 0.23 },
     BLUE = { r = 0.1, g = 0.1, b = 0.25 },
     GREEN = { r = 0.1, g = 0.2, b = 0.15 },
-    PINK = { r = 0.3, g = 0.1, b = 0.2 }
+    PINK = { r = 1.0, g = 0.77, b = 0.83 }
 }
 
 -- Get colors from the user settings

--- a/scripts/notepad/config.lua
+++ b/scripts/notepad/config.lua
@@ -11,6 +11,39 @@
         local editor_width = config.DIMENSIONS.EDITOR.WIDTH
 ]]
 
+-- Configuration will be set by modmain.lua
+local TEXT_COLOR = "WHITE"
+local BG_COLOR = "DARK" 
+local BG_OPACITY = 0.7
+
+-- Color mapping tables for user-selected colors
+local TEXT_COLOR_MAP = {
+    WHITE = { r = 1, g = 1, b = 1, a = 1 },
+    YELLOW = { r = 1, g = 0.9, b = 0.5, a = 1 },
+    LIGHT_BLUE = { r = 0.6, g = 0.8, b = 1, a = 1 },
+    LIGHT_GREEN = { r = 0.6, g = 1, b = 0.6, a = 1 },
+    PINK = { r = 1, g = 0.7, b = 0.9, a = 1 }
+}
+
+local BG_COLOR_MAP = {
+    DARK = { r = 0.1, g = 0.1, b = 0.1 },
+    BROWN = { r = 0.25, g = 0.15, b = 0.1 },
+    GREY = { r = 0.2, g = 0.2, b = 0.23 },
+    BLUE = { r = 0.1, g = 0.1, b = 0.25 },
+    GREEN = { r = 0.1, g = 0.2, b = 0.15 },
+    PINK = { r = 0.3, g = 0.1, b = 0.2 }
+}
+
+-- Get colors from the user settings
+local function GetUserTextColor()
+    return TEXT_COLOR_MAP[TEXT_COLOR] or TEXT_COLOR_MAP.WHITE
+end
+
+local function GetUserBgColor()
+    local color = BG_COLOR_MAP[BG_COLOR] or BG_COLOR_MAP.DARK
+    return { r = color.r, g = color.g, b = color.b, a = BG_OPACITY }
+end
+
 -- Font sizes for different UI elements
 -- All sizes are in game units
 local FONT_SIZES = {
@@ -49,10 +82,10 @@ local DIMENSIONS = {
 -- Values range from 0 to 1
 local COLORS = {
     SHADOW_TINT = { r = 0, g = 0, b = 0, a = 0.2 },        -- Outer shadow color
-    FRAME_TINT = { r = 0.1, g = 0.1, b = 0.1, a = 0.7 },   -- Frame border color
-    TITLE_BG_TINT = { r = 0.1, g = 0.1, b = 0.1, a = 0.8 },-- Title bar background
-    TITLE_TEXT = { r = 1, g = 1, b = 0.8, a = 1 },     -- Title text color
-    EDITOR_TEXT = { r = 1, g = 1, b = 1, a = 1 },          -- Main editor text color
+    FRAME_TINT = GetUserBgColor(),                         -- Frame border color
+    TITLE_BG_TINT = GetUserBgColor(),                      -- Title bar background
+    TITLE_TEXT = GetUserTextColor(),                       -- Title text color
+    EDITOR_TEXT = GetUserTextColor(),                      -- Main editor text color
     SAVE_INDICATOR = { r = 0.5, g = 1, b = 0.5, a = 1 }    -- "Saved" indicator color
 }
 
@@ -66,10 +99,24 @@ local SETTINGS = {
     MAX_LINE_WIDTH = 420                  -- Maximum line width in pixels before forcing newline
 }
 
+-- Function to update configuration with user settings
+local function UpdateConfig(text_color, bg_color, bg_opacity)
+    TEXT_COLOR = text_color or TEXT_COLOR
+    BG_COLOR = bg_color or BG_COLOR
+    BG_OPACITY = bg_opacity or BG_OPACITY
+    
+    -- Update colors based on new settings
+    COLORS.FRAME_TINT = GetUserBgColor()
+    COLORS.TITLE_BG_TINT = GetUserBgColor()
+    COLORS.TITLE_TEXT = GetUserTextColor()
+    COLORS.EDITOR_TEXT = GetUserTextColor()
+end
+
 -- Export all configuration constants
 return {
     FONT_SIZES = FONT_SIZES,
     DIMENSIONS = DIMENSIONS,
     COLORS = COLORS,
-    SETTINGS = SETTINGS
+    SETTINGS = SETTINGS,
+    UpdateConfig = UpdateConfig
 }

--- a/scripts/widgets/notepadwidget.lua
+++ b/scripts/widgets/notepadwidget.lua
@@ -35,7 +35,13 @@ local Config = require "notepad/config"
 local NotepadWidget = Class(Screen, function(self)
     Screen._ctor(self, "NotepadWidget")
     print("[Quick Notes] Creating NotepadWidget")
+
+    -- Ensure config is initialized
+    if _G.InitializeConfig and not _G.CONFIG_INITIALIZED then
+        _G.InitializeConfig()
+    end
     
+
     -- Initialize position tracking
     self.position = {x = 0, y = 0}
     


### PR DESCRIPTION
## Overview

This PR adds color customization and appearance options to the QuickNotes mod, allowing users to personalize their notepad with different text colors, background colors, and transparency settings.

## Changes Made

### New Features
1. **Color Customization System**
   - Added 5 text color options (White, Yellow, Light Blue, Light Green, Pink)
   - Added 6 background color options (Dark, Brown, Grey, Blue, Green, Pink)
   - Added 4 transparency levels for the background

3. **Configuration System Improvements**
   - Centralized color mapping system
   - Proper mod initialization flow
   - Fixed issues with GetModConfigData usage

## Files Changed

### Major Changes
- `modinfo.lua`: Added new configuration options
- `scripts/notepad/config.lua`: Implemented color mapping system
- `modmain.lua`: Added proper configuration initialization

### Documentation Updates
- `README.md`: Updated to reflect new features
- `docs/customization.md`: New documentation for customization features

## Implementation Details

### Configuration System
The implementation uses a two-stage initialization:
1. User settings are loaded in modmain.lua using GetModConfigData()
2. Values are passed to config.lua which maps them to actual RGB colors
3. UI components use these mapped colors consistently

## Testing

The changes have been tested with:
- Different color combinations
- All transparency settings
- Keyboard shortcuts during various notepad states
- Proper initialization sequence

## Compatibility

These changes maintain backward compatibility with existing save files. Users who update will keep their saved notes, and the notepad will initially use default colors until configured.
